### PR TITLE
타이틀, 검색창, 검색결과 레이아웃

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.10.1",
         "styled-components": "^6.0.4"
       },
       "devDependencies": {
@@ -13575,6 +13576,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
+    },
+    "node_modules/react-icons": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
+      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.10.1",
     "styled-components": "^6.0.4"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import CustomThemeProvider from 'contexts/UserThemeProvider';
+import SearchPage from 'pages/SearchPage';
 import GlobalStyle from 'styles/GlobalStyle';
 
 function App() {
@@ -6,6 +7,7 @@ function App() {
     <>
       <CustomThemeProvider>
         <GlobalStyle />
+        <SearchPage />
       </CustomThemeProvider>
     </>
   );

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,0 +1,12 @@
+import { styled } from 'styled-components';
+
+export default function Result() {
+  return <StyledResult>검색 결과</StyledResult>;
+}
+
+const StyledResult = styled.div`
+  background-color: ${(props) => props.theme.focused};
+  border-bottom-left-radius: 20px;
+  border-bottom-right-radius: 20px;
+  padding: 15px;
+`;

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -7,6 +7,9 @@ export default function Result() {
 
   return (
     <StyledResult>
+      <StyledBorder>
+        <div />
+      </StyledBorder>
       <StyledList>
         {data.result.length === 0 && <StyledItem>검색결과가 없습니다.</StyledItem>}
         {data.result.map(({ sickNm }, index) => (
@@ -17,7 +20,20 @@ export default function Result() {
   );
 }
 
+const StyledBorder = styled.div`
+  display: flex;
+  justify-content: center;
+  div {
+    width: 95%;
+    height: 1px;
+    background-color: ${(props) => props.theme.border};
+    position: absolute;
+    top: 0;
+  }
+`;
+
 const StyledResult = styled.div`
+  position: relative;
   width: 100%;
 
   background-color: ${(props) => props.theme.textBackground};

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,15 +1,18 @@
 import { styled } from 'styled-components';
 
 export default function Result() {
-  const data = { result: [] }; // 목데이터
+  const data = {
+    result: []
+  }; // 목데이터
 
   return (
     <StyledResult>
-      <StyledSickList>
+      <StyledList>
+        {data.result.length === 0 && <StyledItem>검색결과가 없습니다.</StyledItem>}
         {data.result.map(({ sickNm }, index) => (
           <StyledSickItem key={index}>{sickNm}</StyledSickItem>
         ))}
-      </StyledSickList>
+      </StyledList>
     </StyledResult>
   );
 }
@@ -24,7 +27,7 @@ const StyledResult = styled.div`
   border-top: none;
 `;
 
-const StyledSickList = styled.ul`
+const StyledList = styled.ul`
   padding: 0;
   margin: 0;
   list-style: none;
@@ -32,8 +35,11 @@ const StyledSickList = styled.ul`
   flex-direction: column;
 `;
 
-const StyledSickItem = styled.li`
+const StyledItem = styled.li`
   padding: 15px;
+`;
+
+const StyledSickItem = styled(StyledItem)`
   cursor: pointer;
   &:hover {
     background-color: ${(props) => props.theme.focused};

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -4,6 +4,8 @@ export default function Result() {
   const data = {
     result: []
   }; // 목데이터
+  const MAX_LENGTH = 10;
+  const RESULT_LENGTH = Math.min(MAX_LENGTH, data.result.length);
 
   return (
     <StyledResult>
@@ -12,9 +14,11 @@ export default function Result() {
       </StyledBorder>
       <StyledList>
         {data.result.length === 0 && <StyledItem>검색결과가 없습니다.</StyledItem>}
-        {data.result.map(({ sickNm }, index) => (
-          <StyledSickItem key={index}>{sickNm}</StyledSickItem>
-        ))}
+        {data.result
+          .filter((_, index) => index < RESULT_LENGTH)
+          .map(({ sickNm }, index) => (
+            <StyledSickItem key={index}>{sickNm}</StyledSickItem>
+          ))}
       </StyledList>
     </StyledResult>
   );

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,12 +1,41 @@
 import { styled } from 'styled-components';
 
 export default function Result() {
-  return <StyledResult>검색 결과</StyledResult>;
+  const data = { result: [] }; // 목데이터
+
+  return (
+    <StyledResult>
+      <StyledSickList>
+        {data.result.map(({ sickNm }, index) => (
+          <StyledSickItem key={index}>{sickNm}</StyledSickItem>
+        ))}
+      </StyledSickList>
+    </StyledResult>
+  );
 }
 
 const StyledResult = styled.div`
-  background-color: ${(props) => props.theme.focused};
+  background-color: ${(props) => props.theme.textBackground};
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;
+  overflow: hidden;
+  color: ${(props) => props.theme.main};
+  border: ${(props) => props.theme.textBorder};
+  border-top: none;
+`;
+
+const StyledSickList = styled.ul`
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledSickItem = styled.li`
   padding: 15px;
+  cursor: pointer;
+  &:hover {
+    background-color: ${(props) => props.theme.focused};
+  }
 `;

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,6 +1,21 @@
 import { styled } from 'styled-components';
+import ErrorBoundary from './ErrorBoundary';
+import ResultErrorFallback from './ResultErrorFallback';
 
 export default function Result() {
+  return (
+    <StyledResult>
+      <StyledBorder>
+        <div />
+      </StyledBorder>
+      <ErrorBoundary fallback={<ResultErrorFallback />}>
+        <List />
+      </ErrorBoundary>
+    </StyledResult>
+  );
+}
+
+function List() {
   const data = {
     result: []
   }; // 목데이터
@@ -8,33 +23,16 @@ export default function Result() {
   const RESULT_LENGTH = Math.min(MAX_LENGTH, data.result.length);
 
   return (
-    <StyledResult>
-      <StyledBorder>
-        <div />
-      </StyledBorder>
-      <StyledList>
-        {data.result.length === 0 && <StyledItem>검색결과가 없습니다.</StyledItem>}
-        {data.result
-          .filter((_, index) => index < RESULT_LENGTH)
-          .map(({ sickNm }, index) => (
-            <StyledSickItem key={index}>{sickNm}</StyledSickItem>
-          ))}
-      </StyledList>
-    </StyledResult>
+    <StyledList>
+      {data.result.length === 0 && <StyledItem>검색결과가 없습니다.</StyledItem>}
+      {data.result
+        .filter((_, index) => index < RESULT_LENGTH)
+        .map(({ sickNm }, index) => (
+          <StyledSickItem key={index}>{sickNm}</StyledSickItem>
+        ))}
+    </StyledList>
   );
 }
-
-const StyledBorder = styled.div`
-  display: flex;
-  justify-content: center;
-  div {
-    width: 95%;
-    height: 1px;
-    background-color: ${(props) => props.theme.border};
-    position: absolute;
-    top: 0;
-  }
-`;
 
 const StyledResult = styled.div`
   position: relative;
@@ -65,5 +63,17 @@ const StyledSickItem = styled(StyledItem)`
   cursor: pointer;
   &:hover {
     background-color: ${(props) => props.theme.focused};
+  }
+`;
+
+const StyledBorder = styled.div`
+  display: flex;
+  justify-content: center;
+  div {
+    width: 95%;
+    height: 1px;
+    background-color: ${(props) => props.theme.border};
+    position: absolute;
+    top: 0;
   }
 `;

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -18,6 +18,8 @@ export default function Result() {
 }
 
 const StyledResult = styled.div`
+  width: 100%;
+
   background-color: ${(props) => props.theme.textBackground};
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;

--- a/src/components/ResultErrorFallback.tsx
+++ b/src/components/ResultErrorFallback.tsx
@@ -5,9 +5,9 @@ export default function ResultErrorFallback() {
     <StyledResultErrorFallback>
       <div>
         <div>검색도중 오류가 발생하여</div>
-        <div>결과를 불러올 수 없습니다.</div>
+        <div>결과를 불러올 수 없습니다</div>
       </div>
-      <div>불편함을 드려 죄송합니다.</div>
+      <div>불편함을 드려 죄송합니다</div>
     </StyledResultErrorFallback>
   );
 }
@@ -16,6 +16,8 @@ const StyledResultErrorFallback = styled.div`
   font-size: 20px;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  padding: 30px;
   gap: 20px;
   color: ${(props) => props.theme.main};
 `;

--- a/src/components/SearchArea.tsx
+++ b/src/components/SearchArea.tsx
@@ -8,13 +8,9 @@ interface SearchAreaProps {
 }
 
 export default function SearchArea({ isFocused, updateFocused }: SearchAreaProps) {
-  const styleTextField = {
-    borderRadius: isFocused ? '20px 20px 0px 0px' : '20px'
-  };
-
   return (
     <StyledSearchArea>
-      <StyledTextField style={styleTextField} onFocus={() => updateFocused(true)}>
+      <StyledTextField isFocused={isFocused} onFocus={() => updateFocused(true)}>
         <input type='text' placeholder='질환명을 입력해주세요' />
         <IconButton type='button'>
           <RiDeleteBack2Line />
@@ -35,12 +31,12 @@ const IconButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledTextField = styled.div`
+const StyledTextField = styled.div<{ isFocused: boolean }>`
+  background-color: ${(props) => props.theme.textBackground};
   display: flex;
   justify-content: space-between;
   align-items: center;
 
-  background-color: ${(props) => props.theme.focused};
   padding: 15px;
   font-size: 1.25rem;
 
@@ -54,6 +50,10 @@ const StyledTextField = styled.div`
     outline: none;
     border: none;
   }
+
+  border-radius: ${(props) => (props.isFocused ? '20px 20px 0px 0px' : '20px')};
+  border: ${(props) => props.theme.textBorder};
+  border-bottom: ${(props) => (props.isFocused ? 'none' : props.theme.textBorder)};
 `;
 
 const StyledSearchArea = styled.div``;

--- a/src/components/SearchArea.tsx
+++ b/src/components/SearchArea.tsx
@@ -41,6 +41,7 @@ const StyledTextField = styled.div<{ isFocused: boolean }>`
   font-size: 1.25rem;
 
   input {
+    color: ${(props) => props.theme.main};
     font-size: inherit;
     background-color: transparent;
     border: none;

--- a/src/components/SearchArea.tsx
+++ b/src/components/SearchArea.tsx
@@ -57,4 +57,6 @@ const StyledTextField = styled.div<{ isFocused: boolean }>`
   border-bottom: ${(props) => (props.isFocused ? 'none' : props.theme.textBorder)};
 `;
 
-const StyledSearchArea = styled.div``;
+const StyledSearchArea = styled.div`
+  width: 100%;
+`;

--- a/src/components/SearchArea.tsx
+++ b/src/components/SearchArea.tsx
@@ -1,0 +1,59 @@
+import { styled } from 'styled-components';
+import { BiSearch } from 'react-icons/bi';
+import { RiDeleteBack2Line } from 'react-icons/ri';
+
+interface SearchAreaProps {
+  isFocused: boolean;
+  updateFocused: (isFocused: boolean) => void;
+}
+
+export default function SearchArea({ isFocused, updateFocused }: SearchAreaProps) {
+  const styleTextField = {
+    borderRadius: isFocused ? '20px 20px 0px 0px' : '20px'
+  };
+
+  return (
+    <StyledSearchArea>
+      <StyledTextField style={styleTextField} onFocus={() => updateFocused(true)}>
+        <input type='text' placeholder='질환명을 입력해주세요' />
+        <IconButton type='button'>
+          <RiDeleteBack2Line />
+        </IconButton>
+        <IconButton type='button'>
+          <BiSearch />
+        </IconButton>
+      </StyledTextField>
+    </StyledSearchArea>
+  );
+}
+
+const IconButton = styled.button`
+  background-color: transparent;
+  border: none;
+  font-size: inherit;
+  color: ${(props) => props.theme.secondary};
+  cursor: pointer;
+`;
+
+const StyledTextField = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  background-color: ${(props) => props.theme.focused};
+  padding: 15px;
+  font-size: 1.25rem;
+
+  input {
+    font-size: inherit;
+    background-color: transparent;
+    border: none;
+    width: 85%;
+  }
+  input:focus {
+    outline: none;
+    border: none;
+  }
+`;
+
+const StyledSearchArea = styled.div``;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -14,13 +14,17 @@ export default function SearchPage() {
 
   return (
     <StyledSearchPage>
-      <h2>국내 모든 임상시험 검색하고 온라인으로 참여하기</h2>
-      <SearchArea isFocused={isFocused} updateFocused={updateFocused} />
-      {isFocused && (
-        <ErrorBoundary fallback={<ResultErrorFallback />}>
-          <Result />
-        </ErrorBoundary>
-      )}
+      <div>
+        <h2>국내 모든 임상시험 검색하고 온라인으로 참여하기</h2>
+      </div>
+      <div>
+        <SearchArea isFocused={isFocused} updateFocused={updateFocused} />
+        {isFocused && (
+          <ErrorBoundary fallback={<ResultErrorFallback />}>
+            <Result />
+          </ErrorBoundary>
+        )}
+      </div>
     </StyledSearchPage>
   );
 }
@@ -29,9 +33,17 @@ const StyledSearchPage = styled.div`
   height: 100vh;
   display: flex;
   flex-direction: column;
+  align-items: center;
   font-size: 1.25rem;
+  gap: 20px;
 
-  h2 {
+  & > div:nth-child(1) {
+    width: 65%;
+    text-align: center;
     color: ${(props) => props.theme.main};
+  }
+
+  & > div:nth-child(2) {
+    width: 100%;
   }
 `;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -30,4 +30,8 @@ const StyledSearchPage = styled.div`
   display: flex;
   flex-direction: column;
   font-size: 1.25rem;
+
+  h2 {
+    color: ${(props) => props.theme.main};
+  }
 `;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,0 +1,33 @@
+import ErrorBoundary from 'components/ErrorBoundary';
+import Result from 'components/Result';
+import ResultErrorFallback from 'components/ResultErrorFallback';
+import SearchArea from 'components/SearchArea';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+export default function SearchPage() {
+  const [isFocused, setIsFocused] = useState(false);
+
+  const updateFocused = (isFocused: boolean) => {
+    setIsFocused(isFocused);
+  };
+
+  return (
+    <StyledSearchPage>
+      <h2>국내 모든 임상시험 검색하고 온라인으로 참여하기</h2>
+      <SearchArea isFocused={isFocused} updateFocused={updateFocused} />
+      {isFocused && (
+        <ErrorBoundary fallback={<ResultErrorFallback />}>
+          <Result />
+        </ErrorBoundary>
+      )}
+    </StyledSearchPage>
+  );
+}
+
+const StyledSearchPage = styled.div`
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-size: 1.25rem;
+`;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -4,10 +4,12 @@ export const Dark: DefaultTheme = {
   main: '#D4D4D4',
   secondary: '#B7B7B7',
   placeholder: '#A0A0A0',
-  background: '#0D161E',
+  background: '#101316',
+  textBackground: 'transparent',
   icons: '#C6C6C6',
   border: '#A1A1A1',
-  focused: '#333333'
+  focused: '#333333',
+  textBorder: '1px solid #A1A1A1'
 };
 
 export const Light: DefaultTheme = {
@@ -15,8 +17,10 @@ export const Light: DefaultTheme = {
   secondary: '#A1A1A1',
   placeholder: '#C3C3C3',
   background: '#B1DAFF',
+  textBackground: '#FAFAFA',
   icons: '#838383',
   border: '#C7C7C7',
   focused: '#F1F1F1',
-  shadow: '#ABABAB'
+  shadow: '#ABABAB',
+  textBorder: 'none'
 };

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,2 +1,2 @@
-export type TResult = { sickCd: number; sickNm: string };
+export type TResult = { sickCd: string; sickNm: string }[];
 export type TCachedResult = { result: TResult; expired_time: number };

--- a/src/types/styled.d.ts
+++ b/src/types/styled.d.ts
@@ -6,9 +6,11 @@ declare module 'styled-components' {
     secondary: string;
     placeholder: string;
     background: string;
+    textBackground: string;
     icons: string;
     border: string;
     focused: string;
     shadow?: string;
+    textBorder: string;
   }
 }


### PR DESCRIPTION
## 체크리스트

- [x] 기능의 작동에 이상이 없는지 확인했나요?
- [ ] merge 이후 브랜치를 삭제해주세요!

## 작업 내용
- isFocused 상태에 따른 SearchArea, Result 렌더링 및 스타일 변화
- error boundary 작동을 위한 자식 컴포넌트 분리, 레이아웃

|컴포넌트 렌더링 중 에러 발생|SearchArea에 키워드 입력|
|--|--|
|<img width="593" alt="스크린샷 2023-07-18 오후 11 46 14(2)" src="https://github.com/Hyeondoonge/pre-onboarding-11th-4/assets/55647436/e0fa1f54-85fc-4464-ad41-41b9e4756975">|<img width="600" alt="스크린샷 2023-07-18 오후 11 46 51(2)" src="https://github.com/Hyeondoonge/pre-onboarding-11th-4/assets/55647436/dcd48117-dae4-4fe1-910a-0a11c8a898f1">|

## 주요 작업
- SearchPage 컴포넌트 단에서 관리되는 isFocused 상태에 따라 SearchArea, Result의 UI가 변화됨
- Error Boundary가 사용됨에 따라, 에러 상태가 설정됐다면 위 스크린샷과 같이 에러를 렌더링하도록 구현
